### PR TITLE
Preserve blank lines in reports sent via multiple OBX

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageData.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageData.java
@@ -72,6 +72,12 @@ public class HL7MessageData implements InputDataExtractor {
           extractedValues.addAll((List) result);
         } else if (result != null) {
           extractedValues.add(result);
+        } else if (result==null && spec.toString().equals("[OBX.5]")) {
+        	// In this case, we have a report and we need to preserve blank lines, 
+        	// so we add an empty string to the result array.  
+        	// Restricting to OBX.5, but this should be controlled by configuration 
+        	// rather than specific code here.
+        	extractedValues.add("");
         }
       }
       return EvaluationResultFactory.getEvaluationResult(extractedValues);


### PR DESCRIPTION
Tactical fix, specifically checking for OBX.5 fields.