### PR TITLE
Added clarifying comments to diagnostic report yaml

### DIFF
--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -77,7 +77,8 @@ result:
 presentedForm:
    valueOf: datatype/Attachment
    expressionType: resource
-   # This merges all the OBX lines together when there is no id (obx3) and the type is TX (obx2)
+   # This merges all the OBX lines together when there is no id (obx3) and the message has only type 'TX' (obx2). 
+   # Messages with mixed types of OBX segments will not have a presentedForm attachment created.
    condition: $obx2 EQUALS TX && $obx3 NULL
    vars:
       # This concatenates all OBX-5 lines together (the asterisk) and preserves blank lines (the ampersand).  Multiple lines are concatenated with a tilde.


### PR DESCRIPTION
Added comments clarifying that presentedForm will only be added to a DiagnosticReport when all OBX's in the message are of type TX and don't have an id.